### PR TITLE
fix: correct critical typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
-"# Project Simulator" implimentation
+"# Project Simulator" implementation
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-"# Project Simulator" 
+"# Project Simulator" implimentation


### PR DESCRIPTION
- Changed 'implimentation' to 'implementation'
- This was causing confusion for users
